### PR TITLE
Ensure all permissions are correct for application reviews and shelter reviews

### DIFF
--- a/P2/shelters/views/views.py
+++ b/P2/shelters/views/views.py
@@ -215,8 +215,13 @@ class ListOrCreateShelterReview(generics.ListCreateAPIView):
     pagination_class = ApplicationPagination
 
     def get_queryset(self):
+        get_object_or_404(models.Shelter, id=self.kwargs['pk'])
         return models.ShelterReview.objects.filter(shelter_id=self.kwargs['pk'])\
                                             .order_by('-date_created')
+    
+    def perform_create(self, serializer):
+        get_object_or_404(models.Shelter, id=self.kwargs['pk'])
+        serializer.save()
 
 
 # Pet application comments


### PR DESCRIPTION
- Shelter review endpoints now throw 404 when shelter doesn't exist
- Shelter comments are only viewable and creatable by the application owner or the associated shelter