### PR TITLE
fix: display status correctly on my listings page

### DIFF
--- a/P3/frontend/src/components/pet/common.jsx
+++ b/P3/frontend/src/components/pet/common.jsx
@@ -335,7 +335,7 @@ const ListingRows = ({ listings, isShelter, deleteListing }) => {
                             <Chip
                                 variant="ghost"
                                 size="sm"
-                                value={status}
+                                value={status === 'available' ? 'Available' : 'Not Available'}
                                 color={status === 'available' ? "green" : "red"}
                             />
                         </div>


### PR DESCRIPTION
New changes: "NOT_AVAILABLE" -> "NOT AVAILABLE"

<img width="397" alt="image" src="https://github.com/leowrites/PetPal/assets/40612523/cf85fc1e-e648-429f-adf8-0058c8e42462">
