### PR TITLE
Notification message word break

### DIFF
--- a/P3/frontend/src/components/notifications/NotificationList.jsx
+++ b/P3/frontend/src/components/notifications/NotificationList.jsx
@@ -13,11 +13,13 @@ export default function NotificationList({ notifications, createNotificationClic
         <List>
             {notifications.map((notification) => (
                 <ListItem key={notification.id} disabled={loading} selected={false} className="h-[3rem] w-[20rem]" onClick={createNotificationClickHandler(notification)}>
-                        {notification.message}
+                        <div  className="max-w-[15rem] text-ellipsis overflow-hidden break-normal">
+                            {notification.message}
+                        </div>
                         <ListItemSuffix>
                             <div className="flex flex-row items-center">
                                 {!notification.read ? 
-                                    <FaCircle color="orange" className="mr-[.5rem]"/> : 
+                                    <FaCircle color="orange" className="ml-[.25rem] mr-[.5rem]"/> : 
                                     <></>
                                 }
                                 <IconButton variant="text" disabled={loading} onClick={(e) => {


### PR DESCRIPTION
![image](https://github.com/leowrites/PetPal/assets/43834016/3e3ed5d2-9f6d-4c65-abb1-7a7c0dd7f38c)
Now uses ellipses when a word is too long.